### PR TITLE
Remove casting of 'Mandte' in stg_mvke.sql

### DIFF
--- a/models/snowflake_model/stg_mvke.sql
+++ b/models/snowflake_model/stg_mvke.sql
@@ -2,7 +2,6 @@
 
 select
     -- Keys
-    cast("Mandte" as integer)                          as client,
     trim("Matnr")                                     as material_id,    
     trim("Vkorg")                                     as sales_org,
     lpad("Vtweg"::varchar, 2, '0')                     as distribution_channel,


### PR DESCRIPTION
Removed casting of 'Mandte' as integer from the select statement.